### PR TITLE
Update celery and geospaas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ LABEL purpose="Environment for REST API for Django-Geo-SpaaS"
 RUN apt update && \
     apt install -y git && \
     apt clean && rm -rf /var/lib/apt/lists/* && \
-    pip install --no-cache-dir \
-    'celery<5.0' \
-    'django-celery-results<2.0' \
+    pip install --upgrade --no-cache-dir \
+    'celery==5.2.*' \
+    'django-celery-results==2.2.*' \
     django-filter \
     djangorestframework \
     djangorestframework-filters==1.0.0dev2 \

--- a/geospaas_rest_api/v1/apps.py
+++ b/geospaas_rest_api/v1/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class GeospaasRestApiConfig(AppConfig):
-    name = 'geospaas_rest_api_v1'
+    name = 'geospaas_rest_api.v1'


### PR DESCRIPTION
Upgrade celery to 5.2 in the Docker image.
Update geospaas image to the latest one (2.5.1).