### PR TITLE
Add skip_check option to syntool conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update && \
     pip install --upgrade --no-cache-dir \
     'celery==5.2.*' \
     'django-celery-results==2.2.*' \
+    'django==3.*' \
     django-filter \
     djangorestframework \
     djangorestframework-filters==1.0.0dev2 \


### PR DESCRIPTION
Add an option to skip the chek_ingested task when running syntool conversion.
This is useful in cases where multiple Syntool granules can be generated from a GeoSPaaS dataset with successive calls.
For example Argo data from ERDDAP: you will get more data from the same dataset as time goes by, so you need to be able to run the syntool conversion again on the same dataset.